### PR TITLE
add letters_storage option to allow storing emails on aws s3

### DIFF
--- a/app/controllers/letter_opener_web/letters_controller.rb
+++ b/app/controllers/letter_opener_web/letters_controller.rb
@@ -10,13 +10,13 @@ module LetterOpenerWeb
     before_action :load_letter, only: %i[show attachment destroy]
 
     def index
-      @letters = LetterOpenerWeb::Letter.search
+      @letters = letter_model.search
     end
 
     def show
       text = @letter.send("#{params[:style]}_text")
-                    .gsub(/"plain\.html"/, "\"#{routes.letter_path(id: @letter.id, style: 'plain')}\"")
-                    .gsub(/"rich\.html"/, "\"#{routes.letter_path(id: @letter.id, style: 'rich')}\"")
+                    .gsub('"plain.html"', "\"#{routes.letter_path(id: @letter.id, style: 'plain')}\"")
+                    .gsub('"rich.html"', "\"#{routes.letter_path(id: @letter.id, style: 'rich')}\"")
 
       render html: text.html_safe
     end
@@ -26,12 +26,13 @@ module LetterOpenerWeb
       file     = @letter.attachments[filename]
 
       return render plain: 'Attachment not found!', status: 404 unless file.present?
+      return redirect_to(file, allow_other_host: true) if LetterOpenerWeb.config.letters_storage == :s3
 
       send_file(file, filename: filename, disposition: 'inline')
     end
 
     def clear
-      LetterOpenerWeb::Letter.destroy_all
+      letter_model.destroy_all
       redirect_to routes.letters_path
     end
 
@@ -50,13 +51,22 @@ module LetterOpenerWeb
     end
 
     def load_letter
-      @letter = LetterOpenerWeb::Letter.find(params[:id])
+      @letter = letter_model.find(params[:id])
 
       head :not_found unless @letter.valid?
     end
 
     def routes
       LetterOpenerWeb.railtie_routes_url_helpers
+    end
+
+    def letter_model
+      case LetterOpenerWeb.config.letters_storage
+      when :s3
+        LetterOpenerWeb::AwsLetter
+      else
+        LetterOpenerWeb::Letter
+      end
     end
   end
 end

--- a/app/models/letter_opener_web/aws_letter.rb
+++ b/app/models/letter_opener_web/aws_letter.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module LetterOpenerWeb
+  class AwsLetter < BaseLetter
+    def self.aws_list_letters(path = [], **options)
+      LetterOpenerWeb
+        .aws_client
+        .list_objects_v2(
+          bucket: LetterOpenerWeb.config.aws_bucket,
+          prefix: File.join([letters_location, *path].compact),
+          **options
+        )
+    end
+    delegate :aws_list_letters, to: :class
+
+    def self.search
+      letters = aws_list_letters(delimiter: '.html').common_prefixes.map do |prefix|
+        new(id: File.basename(File.dirname(prefix.prefix)))
+      end
+
+      letters.reverse
+    end
+
+    def self.destroy_all
+      letters = aws_list_letters.contents.map(&:key)
+
+      LetterOpenerWeb.aws_client.delete_objects(
+        bucket: LetterOpenerWeb.config.aws_bucket,
+        delete: {
+          objects: letters.map { |key| { key: key } },
+          quiet: false
+        }
+      )
+    end
+
+    def attachments
+      @attachments ||= aws_list_letters([id, 'attachments/']).contents.each_with_object({}) do |file, hash|
+        hash[File.basename(file.key)] = attachment_url(file.key)
+      end
+    end
+
+    def delete
+      return unless valid?
+
+      letters = aws_list_letters([id]).contents.map(&:key)
+
+      LetterOpenerWeb.aws_client.delete_objects(
+        bucket: LetterOpenerWeb.config.aws_bucket,
+        delete: {
+          objects: letters.map { |key| { key: key } },
+          quiet: false
+        }
+      )
+    end
+
+    def valid?
+      aws_list_letters([id]).contents.any?
+    end
+
+    private
+
+    def attachment_url(key)
+      bucket = Aws::S3::Bucket.new(
+        name: LetterOpenerWeb.config.aws_bucket, client: LetterOpenerWeb.aws_client
+      )
+
+      obj = bucket.object(key)
+      obj.presigned_url(:get, expires_in: 1.week.to_i)
+    end
+
+    def objects
+      @objects ||= {}
+    end
+
+    def read_file(style)
+      return objects[style] if objects.key?(style)
+
+      response = LetterOpenerWeb.aws_client
+                                .get_object(
+                                  bucket: LetterOpenerWeb.config.aws_bucket,
+                                  key: File.join(letters_location, id, "#{style}.html")
+                                )
+
+      response.body.read.tap do |value|
+        objects[style] = value
+      end
+    rescue Aws::S3::Errors::NoSuchKey
+      ''
+    end
+
+    def style_exists?(style)
+      return !objects[style].empty? if objects.key?(style)
+
+      objects[style] = read_file(style)
+      !objects[style].empty?
+    end
+  end
+end

--- a/app/models/letter_opener_web/base_letter.rb
+++ b/app/models/letter_opener_web/base_letter.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module LetterOpenerWeb
+  class BaseLetter
+    attr_reader :id, :sent_at
+
+    def initialize(params)
+      @id      = params.fetch(:id)
+      @sent_at = params[:sent_at]
+    end
+
+    def self.letters_location
+      LetterOpenerWeb.config.letters_location
+    end
+    delegate :letters_location, to: :class
+
+    def self.find(id)
+      new(id: id)
+    end
+
+    def headers
+      html = read_file(:rich) if style_exists?('rich')
+      html ||= read_file(:plain)
+
+      # NOTE: This is ugly, we should look into using nokogiri and making that a
+      # dependency of this gem
+      match_data = html.match(%r{<body>\s*<div[^>]+id="container">\s*<div[^>]+id="message_headers">\s*(<dl>.+</dl>)}m)
+      return remove_attachments_link(match_data[1]).html_safe if match_data && match_data[1].present?
+
+      'UNABLE TO PARSE HEADERS'
+    end
+
+    def plain_text
+      @plain_text ||= adjust_link_targets(read_file(:plain))
+    end
+
+    def rich_text
+      @rich_text ||= adjust_link_targets(read_file(:rich))
+    end
+
+    def to_param
+      id
+    end
+
+    def default_style
+      style_exists?('rich') ? 'rich' : 'plain'
+    end
+
+    private
+
+    def remove_attachments_link(headers)
+      xml = REXML::Document.new(headers)
+      if xml.root.elements.size == 10
+        xml.delete_element('//dd[last()]')
+        xml.delete_element('//dt[last()]')
+      end
+      xml.to_s
+    end
+
+    def base_dir_within_letters_location?
+      base_dir.to_s.start_with?(self.class.letters_location.to_s)
+    end
+
+    def adjust_link_targets(contents)
+      # We cannot feed the whole file to a XML parser as some mails are
+      # "complete" (as in they have the whole <html> structure) and letter_opener
+      # prepends some information about the mail being sent, making REXML
+      # complain about it
+      contents.scan(%r{<a\s[^>]+>(?:.|\s)*?</a>}).each do |link|
+        fixed_link = fix_link_html(link)
+        xml        = REXML::Document.new(fixed_link).root
+        next if xml.attributes['href'] =~ /(plain|rich).html/
+
+        xml.attributes['target'] = '_blank'
+        xml.add_text('') unless xml.text
+        contents.gsub!(link, xml.to_s)
+      end
+      contents
+    end
+
+    def fix_link_html(link_html)
+      # REFACTOR: we need a better way of fixing the link inner html
+      link_html.dup.tap do |fixed_link|
+        fixed_link.gsub!('<br>', '<br/>')
+        fixed_link.scan(/<img(?:[^>]+?)>/).each do |img|
+          fixed_img = img.dup
+          fixed_img.gsub!(/>$/, '/>') unless img =~ %r{/>$}
+          fixed_link.gsub!(img, fixed_img)
+        end
+      end
+    end
+  end
+end

--- a/app/models/letter_opener_web/letter.rb
+++ b/app/models/letter_opener_web/letter.rb
@@ -1,64 +1,16 @@
 # frozen_string_literal: true
 
 module LetterOpenerWeb
-  class Letter
-    attr_reader :id, :sent_at
-
-    def self.letters_location
-      @letters_location ||= LetterOpenerWeb.config.letters_location
-    end
-
-    def self.letters_location=(directory)
-      LetterOpenerWeb.configure { |config| config.letters_location = directory }
-      @letters_location = nil
-    end
-
+  class Letter < BaseLetter
     def self.search
-      letters = Dir.glob("#{LetterOpenerWeb.config.letters_location}/*").map do |folder|
+      letters = Dir.glob("#{letters_location}/*").map do |folder|
         new(id: File.basename(folder), sent_at: File.mtime(folder))
       end
       letters.sort_by(&:sent_at).reverse
     end
 
-    def self.find(id)
-      new(id: id)
-    end
-
     def self.destroy_all
-      FileUtils.rm_rf(LetterOpenerWeb.config.letters_location)
-    end
-
-    def initialize(params)
-      @id      = params.fetch(:id)
-      @sent_at = params[:sent_at]
-    end
-
-    def headers
-      html = read_file(:rich) if style_exists?('rich')
-      html ||= read_file(:plain)
-
-      # NOTE: This is ugly, we should look into using nokogiri and making that a
-      # dependency of this gem
-      match_data = html.match(%r{<body>\s*<div[^>]+id="container">\s*<div[^>]+id="message_headers">\s*(<dl>.+</dl>)}m)
-      return remove_attachments_link(match_data[1]).html_safe if match_data && match_data[1].present?
-
-      'UNABLE TO PARSE HEADERS'
-    end
-
-    def plain_text
-      @plain_text ||= adjust_link_targets(read_file(:plain))
-    end
-
-    def rich_text
-      @rich_text ||= adjust_link_targets(read_file(:rich))
-    end
-
-    def to_param
-      id
-    end
-
-    def default_style
-      style_exists?('rich') ? 'rich' : 'plain'
+      FileUtils.rm_rf(letters_location)
     end
 
     def attachments
@@ -79,25 +31,16 @@ module LetterOpenerWeb
 
     private
 
-    def remove_attachments_link(headers)
-      xml = REXML::Document.new(headers)
-      if xml.root.elements.size == 10
-        xml.delete_element('//dd[last()]')
-        xml.delete_element('//dt[last()]')
-      end
-      xml.to_s
+    def style_exists?(style)
+      File.exist?("#{base_dir}/#{style}.html")
     end
 
     def base_dir
-      LetterOpenerWeb.config.letters_location.join(id).cleanpath
+      self.class.letters_location.join(id).cleanpath
     end
 
     def read_file(style)
       File.read("#{base_dir}/#{style}.html")
-    end
-
-    def style_exists?(style)
-      File.exist?("#{base_dir}/#{style}.html")
     end
 
     def exists?
@@ -105,36 +48,7 @@ module LetterOpenerWeb
     end
 
     def base_dir_within_letters_location?
-      base_dir.to_s.start_with?(LetterOpenerWeb.config.letters_location.to_s)
-    end
-
-    def adjust_link_targets(contents)
-      # We cannot feed the whole file to a XML parser as some mails are
-      # "complete" (as in they have the whole <html> structure) and letter_opener
-      # prepends some information about the mail being sent, making REXML
-      # complain about it
-      contents.scan(%r{<a\s[^>]+>(?:.|\s)*?</a>}).each do |link|
-        fixed_link = fix_link_html(link)
-        xml        = REXML::Document.new(fixed_link).root
-        next if xml.attributes['href'] =~ /(plain|rich).html/
-
-        xml.attributes['target'] = '_blank'
-        xml.add_text('') unless xml.text
-        contents.gsub!(link, xml.to_s)
-      end
-      contents
-    end
-
-    def fix_link_html(link_html)
-      # REFACTOR: we need a better way of fixing the link inner html
-      link_html.dup.tap do |fixed_link|
-        fixed_link.gsub!('<br>', '<br/>')
-        fixed_link.scan(/<img(?:[^>]+?)>/).each do |img|
-          fixed_img = img.dup
-          fixed_img.gsub!(/>$/, '/>') unless img =~ %r{/>$}
-          fixed_link.gsub!(img, fixed_img)
-        end
-      end
+      base_dir.to_s.start_with?(self.class.letters_location.to_s)
     end
   end
 end

--- a/app/models/letter_opener_web/s3_message.rb
+++ b/app/models/letter_opener_web/s3_message.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module LetterOpenerWeb
+  class S3Message < LetterOpener::Message
+    def render
+      mail.attachments.each do |attachment|
+        filename = attachment_filename(attachment)
+
+        LetterOpenerWeb.aws_client.put_object(
+          bucket: LetterOpenerWeb.config.aws_bucket,
+          key: "#{@location}/attachments/#{filename}",
+          body: attachment.body.raw_source
+        )
+
+        @attachments << [attachment.filename, "attachments/#{filename}"]
+      end
+
+      LetterOpenerWeb.aws_client.put_object(
+        bucket: LetterOpenerWeb.config.aws_bucket,
+        key: "#{@location}/#{type}.html",
+        body: ERB.new(template).result(binding)
+      )
+    end
+  end
+end

--- a/letter_opener_web.gemspec
+++ b/letter_opener_web.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |gem|
 
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   gem.executables   = gem.files.grep(%r{^exe/}).map { |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
   gem.add_dependency 'actionmailer', '>= 5.2'
+  gem.add_dependency 'aws-sdk-s3', '~> 1.142'
   gem.add_dependency 'letter_opener', '~> 1.7'
   gem.add_dependency 'railties', '>= 5.2'
   gem.add_dependency 'rexml'
@@ -31,4 +31,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rubocop-rails', '~> 2.12'
   gem.add_development_dependency 'rubocop-rspec', '~> 2.5'
   gem.add_development_dependency 'shoulda-matchers', '~> 5.0'
+  gem.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/letter_opener_web.rb
+++ b/lib/letter_opener_web.rb
@@ -3,15 +3,32 @@
 require 'letter_opener_web/version'
 require 'letter_opener_web/engine'
 require 'rexml/document'
+require 'aws-sdk-s3'
 
 module LetterOpenerWeb
   class Config
-    attr_accessor :letters_location
+    attr_accessor(
+      :letters_storage,
+      :aws_access_key_id,
+      :aws_secret_access_key,
+      :aws_region,
+      :aws_bucket
+    )
+
+    def letters_location
+      @letters_location ||=
+        case LetterOpenerWeb.config.letters_storage
+        when :local
+          Rails.root.join('tmp', 'letter_opener')
+        end
+    end
+
+    attr_writer :letters_location
   end
 
   def self.config
     @config ||= Config.new.tap do |conf|
-      conf.letters_location = Rails.root.join('tmp', 'letter_opener')
+      conf.letters_storage = :local
     end
   end
 
@@ -21,5 +38,15 @@ module LetterOpenerWeb
 
   def self.reset!
     @config = nil
+    @aws_client = nil
+    @letters_location = nil
+  end
+
+  def self.aws_client
+    @aws_client ||= ::Aws::S3::Client.new(
+      access_key_id: LetterOpenerWeb.config.aws_access_key_id,
+      secret_access_key: LetterOpenerWeb.config.aws_secret_access_key,
+      region: LetterOpenerWeb.config.aws_region
+    )
   end
 end

--- a/spec/controllers/letter_opener_web/letters_controller_spec.rb
+++ b/spec/controllers/letter_opener_web/letters_controller_spec.rb
@@ -7,6 +7,151 @@ RSpec.describe LetterOpenerWeb::LettersController do
 
   after(:each) { LetterOpenerWeb.reset! }
 
+  context 'when letters location is on AWS S3 bucket' do
+    before do
+      LetterOpenerWeb.configure do |config|
+        config.aws_access_key_id = 'aws_access_key_id'
+        config.aws_secret_access_key = 'aws_secret_access_key'
+        config.aws_region = 'aws_region'
+        config.aws_bucket = 'aws_bucket'
+        config.letters_storage = :s3
+      end
+    end
+
+    describe 'GET index' do
+      before do
+        allow(LetterOpenerWeb::AwsLetter).to receive(:search)
+        get :index
+      end
+
+      it 'searches for all letters' do
+        expect(LetterOpenerWeb::AwsLetter).to have_received(:search)
+      end
+
+      it 'returns an HTML 200 response' do
+        expect(response.status).to eq(200)
+        expect(response.content_type).to eq('text/html; charset=utf-8')
+      end
+    end
+
+    describe 'GET show' do
+      let(:id)         { 'an-id' }
+      let(:rich_text)  { 'rich text href="plain.html"' }
+      let(:plain_text) { 'plain text href="rich.html"' }
+      let(:letter)     { double(:letter, rich_text: rich_text, plain_text: plain_text, id: id) }
+
+      shared_examples 'found letter examples' do |letter_style|
+        before(:each) do
+          expect(LetterOpenerWeb::AwsLetter).to receive(:find).with(id).and_return(letter)
+          expect(letter).to receive(:valid?).and_return(true)
+          get :show, params: { id: id, style: letter_style }
+        end
+
+        it 'renders an HTML 200 response' do
+          expect(response.status).to eq(200)
+          expect(response.content_type).to eq('text/html; charset=utf-8')
+        end
+      end
+
+      context 'rich text version' do
+        include_examples 'found letter examples', 'rich'
+
+        it 'renders the rich text contents' do
+          expect(response.body).to match(/^rich text/)
+        end
+
+        it 'fixes plain text link' do
+          expect(response.body).not_to match(/href="plain.html"/)
+          expect(response.body).to match(/href="#{Regexp.escape letter_path(id: id, style: 'plain')}"/)
+        end
+      end
+
+      context 'plain text version' do
+        include_examples 'found letter examples', 'plain'
+
+        it 'renders the plain text contents' do
+          expect(response.body).to match(/^plain text/)
+        end
+
+        it 'fixes rich text link' do
+          expect(response.body).not_to match(/href="rich.html"/)
+          expect(response.body).to match(/href="#{Regexp.escape letter_path(id: id, style: 'rich')}"/)
+        end
+      end
+
+      context 'with wrong parameters' do
+        it 'should return 404 when invalid id given' do
+          letter = double(:letter, attachments: {}, valid?: false)
+          allow(LetterOpenerWeb::AwsLetter).to receive(:find).with(id).and_return(letter)
+
+          get :show, params: { id: id, style: 'rich' }
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+
+    describe 'GET attachment' do
+      let(:id)              { 'an-id' }
+      let(:attachment_path) { 'path/to/attachment' }
+      let(:file_name)       { 'image.jpg' }
+      let(:letter)          { double(:letter, attachments: { file_name => attachment_path }, id: id) }
+
+      before do
+        allow(LetterOpenerWeb::AwsLetter).to receive(:find).with(id).and_return(letter)
+        allow(letter).to receive(:valid?).and_return(true)
+      end
+
+      it 'redirects to the s3 file' do
+        allow(controller).to receive(:redirect_to) { controller.head :found }
+        get :attachment, params: { id: id, file: file_name.gsub(/\.\w+/, ''), format: File.extname(file_name)[1..] }
+
+        expect(response.status).to eq(302)
+        expect(controller).to have_received(:redirect_to)
+          .with(attachment_path, allow_other_host: true)
+      end
+
+      it "throws a 404 if attachment file can't be found" do
+        get :attachment, params: { id: id, file: 'unknown', format: 'woot' }
+        expect(response.status).to eq(404)
+      end
+    end
+
+    describe 'DELETE clear' do
+      before { allow(LetterOpenerWeb::AwsLetter).to receive(:destroy_all) }
+
+      it 'removes all letters' do
+        delete :clear
+        expect(LetterOpenerWeb::AwsLetter).to have_received(:destroy_all)
+      end
+
+      it 'redirects back to index' do
+        delete :clear
+        expect(response).to redirect_to(letters_path)
+      end
+    end
+
+    describe 'DELETE destroy' do
+      let(:id) { 'an-id' }
+
+      it 'removes the selected letter' do
+        allow_any_instance_of(LetterOpenerWeb::AwsLetter).to receive(:valid?).and_return(true)
+        expect_any_instance_of(LetterOpenerWeb::AwsLetter).to receive(:delete)
+        delete :destroy, params: { id: id }
+      end
+
+      it 'throws a 404 if attachment is not present on s3' do
+        bad_id = '../an-id'
+
+        allow_any_instance_of(LetterOpenerWeb::AwsLetter).to receive(:valid?).and_return(false)
+        expect_any_instance_of(LetterOpenerWeb::AwsLetter).not_to receive(:delete)
+
+        delete :destroy, params: { id: bad_id }
+
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
   describe 'GET index' do
     before do
       allow(LetterOpenerWeb::Letter).to receive(:search)

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -84,7 +84,7 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  config.log_formatter = Logger::Formatter.new
 
   # Use a different logger for distributed setups.
   # require "syslog/logger"

--- a/spec/dummy/config/initializers/application_controller_renderer.rb
+++ b/spec/dummy/config/initializers/application_controller_renderer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # ActiveSupport::Reloader.to_prepare do

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/spec/dummy/config/initializers/content_security_policy.rb
+++ b/spec/dummy/config/initializers/content_security_policy.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy

--- a/spec/dummy/config/initializers/inflections.rb
+++ b/spec/dummy/config/initializers/inflections.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/spec/dummy/config/initializers/mime_types.rb
+++ b/spec/dummy/config/initializers/mime_types.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/spec/dummy/config/initializers/permissions_policy.rb
+++ b/spec/dummy/config/initializers/permissions_policy.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Define an application-wide HTTP permissions policy. For further
 # information see https://developers.google.com/web/updates/2018/06/feature-policy
 #

--- a/spec/letter_opener_web_spec.rb
+++ b/spec/letter_opener_web_spec.rb
@@ -7,9 +7,12 @@ RSpec.describe LetterOpenerWeb do
   after(:each) { described_class.reset! }
 
   describe '.config' do
-    it 'sets defaults' do
-      expected = Rails.root.join('tmp', 'letter_opener')
-      expect(subject.config.letters_location).to eq(expected)
+    it 'sets default letters_storage' do
+      expect(subject.config.letters_storage).to eq(:local)
+    end
+
+    it 'sets default letters_location' do
+      expect(subject.config.letters_location).to eq(Rails.root.join('tmp', 'letter_opener'))
     end
   end
 

--- a/spec/models/letter_opener_web/aws_letter_spec.rb
+++ b/spec/models/letter_opener_web/aws_letter_spec.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+RSpec.describe LetterOpenerWeb::AwsLetter do
+  subject { described_class.new(id: letter_id) }
+
+  let(:aws_access_key_id)     { 'aws_access_key_id' }
+  let(:aws_secret_access_key) { 'aws_secret_access_key' }
+  let(:aws_region)            { 'aws_region' }
+  let(:aws_bucket)            { 'aws_bucket' }
+  let(:letter_id)             { 'letter_id' }
+  let(:letters_location)      { nil }
+
+  let(:s3_client) do
+    instance_double(Aws::S3::Client)
+  end
+
+  before :each do
+    LetterOpenerWeb.configure do |config|
+      config.letters_storage = :s3
+      config.letters_location = letters_location
+      config.aws_access_key_id = aws_access_key_id
+      config.aws_secret_access_key = aws_secret_access_key
+      config.aws_region = aws_region
+      config.aws_bucket = aws_bucket
+    end
+
+    allow(Aws::S3::Client)
+      .to receive(:new)
+      .with(
+        access_key_id: aws_access_key_id,
+        secret_access_key: aws_secret_access_key,
+        region: aws_region
+      )
+      .and_return(s3_client)
+  end
+
+  after :each do
+    LetterOpenerWeb.reset!
+  end
+
+  describe '#letters_location' do
+    subject { described_class.letters_location }
+
+    context 'with a nil given value in LetterOpenerWeb.configure' do
+      let(:letters_location) { nil }
+
+      it { is_expected.to eq(nil) }
+    end
+
+    context 'with any value in LetterOpenerWeb.configure' do
+      let(:letters_location) { 'letters_location' }
+
+      it { is_expected.to eq(letters_location) }
+    end
+  end
+
+  describe '#search' do
+    it 'returns all letters', aggregates_failure: true do
+      expect(s3_client)
+        .to receive(:list_objects_v2)
+        .with(bucket: aws_bucket, prefix: '', delimiter: '.html')
+        .and_return(
+          instance_double(Aws::S3::Types::ListObjectsV2Output, common_prefixes: [
+                            instance_double(Aws::S3::Types::CommonPrefix,
+                                            prefix: 'location/to/letters/1111_1111/toto.html'),
+                            instance_double(Aws::S3::Types::CommonPrefix, prefix: '2222_2222/toto.html')
+                          ])
+        )
+
+      letters = described_class.search
+
+      expect(letters.size).to eq(2)
+      expect(letters.first.id).to eq('2222_2222')
+      expect(letters.last.id).to eq('1111_1111')
+    end
+  end
+
+  describe '#destroy_all' do
+    let(:s3_content) { instance_double(Aws::S3::Types::Object, key: '123') }
+
+    it 'removes all letters', aggregates_failure: true do
+      expect(s3_client)
+        .to receive(:list_objects_v2)
+        .with(bucket: aws_bucket, prefix: '')
+        .and_return(
+          instance_double(Aws::S3::Types::ListObjectsV2Output, contents: [s3_content])
+        )
+      expect(s3_client)
+        .to receive(:delete_objects)
+        .with(
+          bucket: aws_bucket,
+          delete: {
+            objects: [key: s3_content.key],
+            quiet: false
+          }
+        )
+
+      described_class.destroy_all
+    end
+  end
+
+  describe '.delete' do
+    let(:s3_content) { instance_double(Aws::S3::Types::Object, key: '123') }
+
+    it 'does not remove letter if it does not exist', aggregates_failure: true do
+      expect(s3_client)
+        .to receive(:list_objects_v2)
+        .with(bucket: aws_bucket, prefix: letter_id)
+        .and_return(
+          instance_double(Aws::S3::Types::ListObjectsV2Output, contents: [])
+        )
+      expect(s3_client)
+        .not_to receive(:delete_objects)
+
+      subject.delete
+    end
+
+    it 'removes letter if it exists' do
+      expect(s3_client)
+        .to receive(:list_objects_v2)
+        .with(bucket: aws_bucket, prefix: letter_id)
+        .and_return(
+          instance_double(Aws::S3::Types::ListObjectsV2Output, contents: [s3_content])
+        )
+        .twice
+
+      expect(s3_client)
+        .to receive(:delete_objects)
+        .with(
+          bucket: aws_bucket,
+          delete: {
+            objects: [key: s3_content.key],
+            quiet: false
+          }
+        )
+
+      subject.delete
+    end
+  end
+
+  describe '.valid?' do
+    it 'returns true if the letter exists' do
+      expect(s3_client)
+        .to receive(:list_objects_v2)
+        .with(bucket: aws_bucket, prefix: letter_id)
+        .and_return(
+          instance_double(Aws::S3::Types::ListObjectsV2Output, contents: [
+                            instance_double(Aws::S3::Types::Object)
+                          ])
+        )
+
+      expect(subject).to be_valid
+    end
+
+    it 'returns false if the letter does not exist' do
+      expect(s3_client)
+        .to receive(:list_objects_v2)
+        .with(bucket: aws_bucket, prefix: letter_id)
+        .and_return(
+          instance_double(Aws::S3::Types::ListObjectsV2Output, contents: [])
+        )
+
+      expect(subject).not_to be_valid
+    end
+  end
+
+  describe '.attachments' do
+    let(:s3_content)    { instance_double(Aws::S3::Types::Object, key: '123') }
+    let(:presigned_url) { 'https://presigned-url' }
+    let(:s3_bucket)     { instance_double(Aws::S3::Bucket, object: double) }
+    let(:s3_object)     { instance_double(Aws::S3::Object, presigned_url: double) }
+
+    it 'returns attachments with presigned urls' do
+      expect(s3_client)
+        .to receive(:list_objects_v2)
+        .with(bucket: aws_bucket, prefix: "#{letter_id}/attachments/")
+        .and_return(
+          instance_double(Aws::S3::Types::ListObjectsV2Output, contents: [s3_content])
+        )
+      expect(Aws::S3::Bucket)
+        .to receive(:new)
+        .with(name: aws_bucket, client: s3_client)
+        .and_return(s3_bucket)
+      expect(s3_bucket)
+        .to receive(:object)
+        .with(s3_content.key)
+        .and_return(s3_object)
+      expect(s3_object)
+        .to receive(:presigned_url)
+        .with(:get, expires_in: 1.week.to_i)
+        .and_return(presigned_url)
+
+      expect(subject.attachments).to eq(s3_content.key => presigned_url)
+    end
+  end
+end

--- a/spec/models/letter_opener_web/letter_spec.rb
+++ b/spec/models/letter_opener_web/letter_spec.rb
@@ -33,12 +33,10 @@ RSpec.describe LetterOpenerWeb::Letter do
 
     %w[1111_1111 2222_2222].each do |folder|
       FileUtils.mkdir_p("#{location}/#{folder}")
-      File.open("#{location}/#{folder}/plain.html", 'w') { |f| f.write("Plain text for #{folder}") }
-      File.open("#{location}/#{folder}/rich.html", 'w')  { |f| f.write(rich_text(folder)) }
+      File.write("#{location}/#{folder}/plain.html", "Plain text for #{folder}")
+      File.write("#{location}/#{folder}/rich.html", rich_text(folder))
       FileUtils.mkdir_p("#{Rails.root.join('tmp', 'letter_opener')}/#{folder}")
-      File.open("#{Rails.root.join('tmp', 'letter_opener')}/#{folder}/rich.html", 'w') do |f|
-        f.write("Rich text for #{folder}")
-      end
+      File.write("#{Rails.root.join('tmp', 'letter_opener')}/#{folder}/rich.html", "Rich text for #{folder}")
     end
   end
 
@@ -167,6 +165,7 @@ RSpec.describe LetterOpenerWeb::Letter do
 
     it 'removes the letter with given id' do
       subject
+
       directories = Dir["#{location}/*"]
       expect(directories.count).to eql(1)
       expect(directories.first).not_to match(id)


### PR DESCRIPTION
J'ai repris la PR du gars => https://github.com/fgrehm/letter_opener_web/pull/129
J'ai fait quelques modifs nottement pour que la config `letters_location`  ne soit pas overridé pour devenir la config du storage et qu'on puisse choisir le prefix au sein du bucket S3.
Testé en local ça fonctionne super bien.